### PR TITLE
Refactor bot command definition style 

### DIFF
--- a/internal/matrix/bot.go
+++ b/internal/matrix/bot.go
@@ -1,13 +1,13 @@
 package matrix
 
 import (
+	"fmt"
+	"strings"
 	"time"
 
-	"github.com/pkg/errors"
-
 	"github.com/matrix-org/gomatrix"
+	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-
 	"github.com/snapp-incubator/matrix-on-call-bot/internal/model"
 )
 
@@ -29,6 +29,8 @@ type Bot struct {
 	roomRepo     model.RoomRepo
 	shiftRepo    model.ShiftRepo
 	followUpRepo model.FollowUpRepo
+
+	commands []Command
 
 	stopSignal chan struct{}
 }
@@ -91,7 +93,7 @@ func (b *Bot) RegisterListeners() error {
 			return
 		}
 
-		if err := b.Handle(event); err != nil {
+		if err := b.matchAndHandleEvent(event); err != nil {
 			logrus.WithFields(logrus.Fields{
 				"error": err.Error(),
 				"event": event,
@@ -100,6 +102,37 @@ func (b *Bot) RegisterListeners() error {
 	})
 
 	return nil
+}
+
+func (b *Bot) matchAndHandleEvent(event *gomatrix.Event) error {
+	raw, ok := event.Content["body"].(string)
+	if !ok {
+		return ErrInvalidBody
+	}
+
+	parts := strings.Split(raw, " ")
+
+	if len(parts) < minCommandLength {
+		return ErrInvalidCommand
+	}
+
+	if parts[0][0] != '!' {
+		return nil
+	}
+
+	for _, cmd := range b.commands {
+		if cmd.Match(parts[0]) {
+			// each command message can be handled by only one command handler.
+			err := cmd.Handle(event)
+			if err != nil {
+				return fmt.Errorf("command type %t returned error: %w", cmd, err)
+			}
+
+			return nil
+		}
+	}
+
+	return ErrUnknownCommand
 }
 
 func (b *Bot) Run() {

--- a/internal/matrix/bot.go
+++ b/internal/matrix/bot.go
@@ -8,6 +8,7 @@ import (
 	"github.com/matrix-org/gomatrix"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+	"github.com/snapp-incubator/matrix-on-call-bot/internal/matrix/command"
 	"github.com/snapp-incubator/matrix-on-call-bot/internal/model"
 )
 
@@ -107,13 +108,13 @@ func (b *Bot) RegisterListeners() error {
 func (b *Bot) matchAndHandleEvent(event *gomatrix.Event) error {
 	raw, ok := event.Content["body"].(string)
 	if !ok {
-		return ErrInvalidBody
+		return command.ErrInvalidBody
 	}
 
 	parts := strings.Split(raw, " ")
 
 	if len(parts) < minCommandLength {
-		return ErrInvalidCommand
+		return command.ErrInvalidCommand
 	}
 
 	if parts[0][0] != '!' {
@@ -123,7 +124,7 @@ func (b *Bot) matchAndHandleEvent(event *gomatrix.Event) error {
 	for _, cmd := range b.commands {
 		if cmd.Match(parts[0]) {
 			// each command message can be handled by only one command handler.
-			err := cmd.Handle(event)
+			err := cmd.Handle(event, parts)
 			if err != nil {
 				return fmt.Errorf("command type %t returned error: %w", cmd, err)
 			}
@@ -132,7 +133,7 @@ func (b *Bot) matchAndHandleEvent(event *gomatrix.Event) error {
 		}
 	}
 
-	return ErrUnknownCommand
+	return command.ErrUnknownCommand
 }
 
 func (b *Bot) Run() {

--- a/internal/matrix/command.go
+++ b/internal/matrix/command.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"math"
-	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -39,16 +38,11 @@ var (
 	ErrInvalidCommand = errors.New("invalid command")
 	ErrUnknownCommand = errors.New("unknown command")
 	ErrInvalidBody    = errors.New("invalid body")
-	ErrInvalidType    = errors.New("invalid type")
-
-	// Regexp is a compiled regular expression that can extract data in a message containing people mentioning (like:
-	// @ahmad.anvari:snapp.cab).
-	Regexp = regexp.MustCompile(`<a href="https://matrix.to/#/(.*?)">(.*?)</a>`)
 )
 
 type Command interface {
 	Match(message string) bool
-	Handle(event *gomatrix.Event) error
+	Handle(event *gomatrix.Event, messageParts []string) error
 }
 
 //nolint:cyclop

--- a/internal/matrix/command.go
+++ b/internal/matrix/command.go
@@ -20,14 +20,7 @@ const (
 	incoming string = "incoming"
 	outgoing string = "outgoing"
 
-	ListShift        Head = "!listshifts" // !listshifts
-	minCommandLength int  = 1
-
-	CreateShift          Head = "!startshift" // !startshift <comma separated oncall names>
-	minCreateShiftLength int  = 1
-
-	EndShift          Head = "!endshift" // !endshift <shift id>
-	minEndShiftLength int  = 2
+	minCommandLength int = 1
 
 	CreateFollowUp          Head = "!followup" // !followup <category: incoming|outgoing> <initiator> <description>
 	minCreateFollowUpLength int  = 4
@@ -76,12 +69,6 @@ func (b *Bot) Handle(event *gomatrix.Event) error {
 	}
 
 	switch Head(parts[0]) {
-	case CreateShift:
-		return b.createShift(event, parts)
-	case EndShift:
-		return b.endShift(event, parts)
-	case ListShift:
-		return b.listShifts(event)
 	case CreateFollowUp:
 		return b.createFollowUp(event, parts)
 	case ListFollowUp:
@@ -95,151 +82,6 @@ func (b *Bot) Handle(event *gomatrix.Event) error {
 	default:
 		return ErrUnknownCommand
 	}
-}
-
-//nolint:funlen,cyclop
-func (b *Bot) createShift(event *gomatrix.Event, parts []string) error {
-	if len(parts) < minCreateShiftLength {
-		return ErrInvalidCommand
-	}
-
-	formattedBody, found := event.Content["formatted_body"]
-	if !found && len(parts) > 1 {
-		if _, err := b.cli.SendText(event.RoomID, InvalidShiftStart); err != nil {
-			return errors.Wrap(err, "error sending invalid shift start")
-		}
-	}
-
-	mxids := make([]string, 0)
-	names := make([]string, 0)
-	mentions := make([]string, 0)
-
-	if len(parts) == 1 {
-		mxids = append(mxids, event.Sender)
-
-		displayName, err := b.cli.GetDisplayName(event.Sender)
-		if err != nil {
-			return errors.Wrap(err, "error getting the display name of the event sender")
-		}
-
-		mentions = append(mentions, b.mentionedText(event.Sender, displayName.DisplayName))
-		names = append(names, displayName.DisplayName)
-	} else {
-		formattedBodyStr, ok := formattedBody.(string)
-		if !ok {
-			return errors.Wrap(ErrInvalidType, "error getting the display name of the event sender")
-		}
-
-		items := Regexp.FindAllStringSubmatch(formattedBodyStr, -1)
-		for _, parts := range items {
-			mentions = append(mentions, parts[0])
-			mxids = append(mxids, parts[1])
-			names = append(names, parts[2])
-		}
-	}
-
-	active, err := b.shiftRepo.Active(event.RoomID)
-	if err != nil {
-		return errors.Wrap(err, "error getting active shifts")
-	}
-
-	//nolint:godox
-	// TODO: Check weather this condition should be checked or not
-	if len(active) > 0 {
-		if _, err := b.cli.SendText(event.RoomID, ActiveShiftOngoing); err != nil {
-			return errors.Wrap(err, "error sending active shift message")
-		}
-
-		return nil
-	}
-
-	now := time.Now()
-
-	for _, mxid := range mxids {
-		//nolint:godox
-		// TODO: Create a bulk Create method
-		if err := b.shiftRepo.Create(&model.Shift{
-			RoomID:    event.RoomID,
-			Sender:    event.Sender,
-			Holders:   mxid,
-			StartTime: now,
-			EndTime:   nil,
-		}); err != nil {
-			return errors.Wrap(err, "error saving shift")
-		}
-	}
-
-	formattedTime := now.Local().Format(time.RFC850)
-
-	_, err = b.cli.SendFormattedText(event.RoomID, fmt.Sprintf(ShiftStarted, strings.Join(names, " "), formattedTime),
-		fmt.Sprintf(ShiftStarted, strings.Join(mentions, " "), formattedTime))
-	if err != nil {
-		return errors.Wrap(err, "error sending shift created message")
-	}
-
-	return nil
-}
-
-func (b *Bot) endShift(event *gomatrix.Event, parts []string) error {
-	if len(parts) < minEndShiftLength {
-		return ErrInvalidCommand
-	}
-
-	shiftID, err := strconv.Atoi(parts[1])
-	if err != nil {
-		return errors.Wrap(err, "invalid shift id")
-	}
-
-	now := time.Now()
-
-	if err := b.shiftRepo.Update(&model.Shift{
-		ID:      shiftID,
-		EndTime: &now,
-	}); err != nil {
-		return errors.Wrap(err, "error updating shift")
-	}
-
-	_, err = b.cli.SendFormattedText(event.RoomID, fmt.Sprintf(ShiftEnd, shiftID), fmt.Sprintf(ShiftEndFormatted, shiftID))
-	if err != nil {
-		return errors.Wrap(err, "error sending shift end message")
-	}
-
-	return nil
-}
-
-func (b *Bot) listShifts(event *gomatrix.Event) error {
-	list, err := b.shiftRepo.Get(event.RoomID)
-	if err != nil {
-		return errors.Wrap(err, "error getting shifts")
-	}
-
-	message := ""
-
-	for _, item := range list {
-		end := "-"
-		emoji := "🟢"
-
-		if item.EndTime != nil {
-			end = item.EndTime.Local().Format(time.RFC850)
-			emoji = "⚪️"
-		}
-
-		displayName, err := b.cli.GetDisplayName(item.Holders)
-		if err != nil {
-			return errors.Wrap(err, "error getting the display name of the event sender")
-		}
-
-		message += fmt.Sprintf(ShiftItem, emoji,
-			item.StartTime.Local().Format(time.RFC850), end, b.mentionedText(item.Holders, displayName.DisplayName), item.ID)
-	}
-
-	message = fmt.Sprintf(ShiftList, message)
-
-	if _, err := b.cli.SendFormattedText(event.RoomID, "", message); err != nil {
-		return errors.Wrap(err, "error sending shifts list")
-	}
-
-	return nil
 }
 
 func (b *Bot) createFollowUp(event *gomatrix.Event, parts []string) error {

--- a/internal/matrix/command.go
+++ b/internal/matrix/command.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/matrix-org/gomatrix"
 	"github.com/pkg/errors"
-
 	"github.com/snapp-incubator/matrix-on-call-bot/internal/model"
 )
 
@@ -53,6 +52,11 @@ var (
 	// @ahmad.anvari:snapp.cab).
 	Regexp = regexp.MustCompile(`<a href="https://matrix.to/#/(.*?)">(.*?)</a>`)
 )
+
+type Command interface {
+	Match(message string) bool
+	Handle(event *gomatrix.Event) error
+}
 
 //nolint:cyclop
 func (b *Bot) Handle(event *gomatrix.Event) error {

--- a/internal/matrix/command/error.go
+++ b/internal/matrix/command/error.go
@@ -1,0 +1,10 @@
+package command
+
+import "errors"
+
+var (
+	ErrInvalidCommand = errors.New("invalid command")
+	ErrUnknownCommand = errors.New("unknown command")
+	ErrInvalidBody    = errors.New("invalid body")
+	ErrInvalidType    = errors.New("invalid type")
+)

--- a/internal/matrix/command/shift.go
+++ b/internal/matrix/command/shift.go
@@ -1,0 +1,162 @@
+package command
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/matrix-org/gomatrix"
+	"github.com/pkg/errors"
+	"github.com/snapp-incubator/matrix-on-call-bot/internal/matrix"
+	"github.com/snapp-incubator/matrix-on-call-bot/internal/matrix/message"
+	"github.com/snapp-incubator/matrix-on-call-bot/internal/model"
+)
+
+const (
+	// check if command starts with
+	// !startshift or
+	// !endshift or
+	// !listshifts.
+	startShiftParseRegexString = "^!startshift|^!endshift|^!listshifts"
+
+	minCreateShiftLength int = 2
+
+	minEndShiftLength int = 2
+)
+
+type Shift struct {
+	parseRegex *regexp.Regexp
+	shiftRepo  model.ShiftRepo
+	client     *gomatrix.Client
+}
+
+func NewShiftCmd(repo model.ShiftRepo, client *gomatrix.Client) (*Shift, error) {
+	regex := regexp.MustCompile(startShiftParseRegexString)
+
+	return &Shift{
+		parseRegex: regex,
+		shiftRepo:  repo,
+		client:     client,
+	}, nil
+}
+
+func (s *Shift) Match(message string) bool {
+	return s.parseRegex.MatchString(message)
+}
+
+func (s *Shift) Handle(event *gomatrix.Event) error {
+	raw, ok := event.Content["body"].(string)
+	if !ok {
+		return matrix.ErrInvalidBody
+	}
+
+	parts := strings.Split(raw, " ")
+
+	switch parts[0] {
+	case "!startshift":
+		return s.startShift(event, parts)
+	case "!endshift":
+		return s.endShift(event, parts)
+	case "!listshifts":
+		return s.listShifts(event)
+	}
+
+	return nil
+}
+
+func (s *Shift) startShift(event *gomatrix.Event, parts []string) error {
+	if len(parts) < minCreateShiftLength {
+		return matrix.ErrInvalidCommand
+	}
+
+	active, err := s.shiftRepo.Active(event.RoomID)
+	if err != nil {
+		return errors.Wrap(err, "error getting active shifts")
+	}
+
+	if len(active) > 0 {
+		if _, err = s.client.SendText(event.RoomID, message.ActiveShiftOngoing); err != nil {
+			return errors.Wrap(err, "error sending active shift message")
+		}
+
+		return nil
+	}
+
+	now := time.Now()
+
+	if err = s.shiftRepo.Create(&model.Shift{
+		RoomID:    event.RoomID,
+		Sender:    event.Sender,
+		Holders:   parts[1],
+		StartTime: now,
+		EndTime:   nil,
+	}); err != nil {
+		return errors.Wrap(err, "error saving shift")
+	}
+
+	_, err = s.client.SendFormattedText(event.RoomID, "",
+		fmt.Sprintf(message.ShiftStarted, now.Local().Format(time.RFC850), message.FormatCommaSeperatedList(parts[1])))
+	if err != nil {
+		return errors.Wrap(err, "error sending shift created message")
+	}
+
+	return nil
+}
+
+func (s *Shift) endShift(event *gomatrix.Event, parts []string) error {
+	if len(parts) < minEndShiftLength {
+		return matrix.ErrInvalidCommand
+	}
+
+	shiftID, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return errors.Wrap(err, "invalid shift id")
+	}
+
+	now := time.Now()
+
+	if err = s.shiftRepo.Update(&model.Shift{
+		ID:      shiftID,
+		EndTime: &now,
+	}); err != nil {
+		return errors.Wrap(err, "error updating shift")
+	}
+
+	if _, err = s.client.SendFormattedText(event.RoomID, "", fmt.Sprintf(message.ShiftEnd, shiftID)); err != nil {
+		return errors.Wrap(err, "error sending shift end message")
+	}
+
+	return nil
+}
+
+func (s *Shift) listShifts(event *gomatrix.Event) error {
+	list, err := s.shiftRepo.Get(event.RoomID)
+	if err != nil {
+		return errors.Wrap(err, "error getting shifts")
+	}
+
+	msg := new(strings.Builder)
+
+	for _, item := range list {
+		end := "-"
+		emoji := "🟢"
+
+		if item.EndTime != nil {
+			end = item.EndTime.Local().Format(time.RFC850)
+			emoji = "⚪️"
+		}
+
+		msg.WriteString(fmt.Sprintf(message.ShiftItem, emoji,
+			item.StartTime.Local().Format(time.RFC850), end, message.FormatCommaSeperatedList(item.Holders), item.ID))
+	}
+
+	response := fmt.Sprintf(message.ShiftList, msg.String())
+
+	if _, err = s.client.SendFormattedText(event.RoomID, "", response); err != nil {
+		return errors.Wrap(err, "error sending shifts list")
+	}
+
+	return nil
+}

--- a/internal/matrix/message/shift.go
+++ b/internal/matrix/message/shift.go
@@ -1,10 +1,11 @@
 package message
 
 const (
-	ShiftStarted         = "Shift started at %s. Holders are <b>%s</b>."
-	ShiftItem            = "<li>%s <b>Start time</b>: %s | <b>End time</b>: %s</li> | <b>Holders</b>: %s | <b>id</b>: %d"
-	ShiftList            = `<ol>%s</ol>`
-	ShiftEnd             = "Shift with id: <b>%d</b> ended. Good job! :)"
-	ActiveShiftOngoing   = "There's an active shift still in progress. You can't start a new one."
-	NoActiveShiftOngoing = "There's no active shift. Create one first."
+	ShiftStarted       = "Shift started at %s. Holders are <b>%s</b>."
+	ShiftItem          = "<li>%s <b>Start time</b>: %s | <b>End time</b>: %s</li> | <b>Holders</b>: %s | <b>id</b>: %d"
+	ShiftList          = `<ol>%s</ol>`
+	ShiftEnd           = "Shift with id: <b>%d</b> ended. Good job! :)"
+	ActiveShiftOngoing = "There's an active shift still in progress. You can't start a new one."
+	ShiftEndFormatted  = "Shift with id: <b>%d</b> ended. Good job! :)"
+	InvalidShiftStart  = "Please mention the on call people."
 )

--- a/internal/matrix/message/shift.go
+++ b/internal/matrix/message/shift.go
@@ -1,0 +1,10 @@
+package message
+
+const (
+	ShiftStarted         = "Shift started at %s. Holders are <b>%s</b>."
+	ShiftItem            = "<li>%s <b>Start time</b>: %s | <b>End time</b>: %s</li> | <b>Holders</b>: %s | <b>id</b>: %d"
+	ShiftList            = `<ol>%s</ol>`
+	ShiftEnd             = "Shift with id: <b>%d</b> ended. Good job! :)"
+	ActiveShiftOngoing   = "There's an active shift still in progress. You can't start a new one."
+	NoActiveShiftOngoing = "There's no active shift. Create one first."
+)

--- a/internal/matrix/message/util.go
+++ b/internal/matrix/message/util.go
@@ -1,13 +1,5 @@
 package message
 
-import "strings"
-
-func FormatCommaSeperatedList(in string) string {
-	items := strings.Split(in, ",")
-
-	for i := range items {
-		items[i] = strings.TrimSpace(items[i])
-	}
-
-	return strings.Join(items, ", ")
+func MentionedText(id, name string) string {
+	return `<a href="https://matrix.to/#/` + id + `">` + name + `</a>`
 }

--- a/internal/matrix/message/util.go
+++ b/internal/matrix/message/util.go
@@ -1,0 +1,13 @@
+package message
+
+import "strings"
+
+func FormatCommaSeperatedList(in string) string {
+	items := strings.Split(in, ",")
+
+	for i := range items {
+		items[i] = strings.TrimSpace(items[i])
+	}
+
+	return strings.Join(items, ", ")
+}


### PR DESCRIPTION
I created a new style to define new bot commands, which I believe is more human-readable and easier to maintain.
With this model, each command will have a file in the `command` and `message` packages representing the command definition and its message templates.


For pattern matching, each command will have to define a regular expression for it's command messages in a `Match(message string) bool` function. It must also have a `Handle(event *gomatrix.Event) error` for command handling.


**This PR is not ready for merge**. We need to migrate all commands to the new style if the new style is acceptable.