### PR TITLE
Fix missing ca-certificates inside runtime container

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -21,4 +21,4 @@ jobs:
       - uses: golangci/golangci-lint-action@v3
         name: golangci-lint
         with:
-          version: v1.46.2
+          version: v1.55.2

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version: 1.21
 
       - uses: actions/checkout@v3
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,3 +5,6 @@ linters:
     - exhaustivestruct
     - exhaustruct
     - nolintlint
+    - depguard
+    - gosmopolitan
+    - goconst

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18.6 AS build
+FROM golang:1.21 AS build
 
 RUN mkdir -p /src
 
@@ -11,6 +11,8 @@ COPY . /src
 RUN make build-linux
 
 FROM debian:11.4-slim
+
+RUN apt update && apt install -y ca-certificates tzdata
 
 COPY --from=build /src/matrix-on-call-bot /usr/local/bin/
 

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ format: check-formatter
 	find . -type f -name "*.go" -not -path "./vendor/*" | xargs -n 1 -I R gofumpt -w R
 
 check-linter:
-	which golangci-lint || go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.46.2
+	which golangci-lint || go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.55.2
 
 lint: check-linter
 	golangci-lint run ./...

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/snapp-incubator/matrix-on-call-bot
 
-go 1.18
+go 1.21
 
 require (
 	github.com/go-playground/validator/v10 v10.11.0

--- a/go.sum
+++ b/go.sum
@@ -838,6 +838,7 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pquerna/cachecontrol v0.0.0-20171018203845-0dec1b30a021/go.mod h1:prYjPmNq4d1NPVmpShWobRqXY3q7Vp+80DqgxxUrUIA=
 github.com/prashantv/gostub v1.1.0 h1:BTyx3RfQjRHnUWaGF9oQos79AlQ5k8WNktv7VGvVH4g=
+github.com/prashantv/gostub v1.1.0/go.mod h1:A5zLQHz7ieHGG7is6LLXLz7I8+3LZzsrV0P1IAHhP5U=
 github.com/prometheus/client_golang v0.0.0-20180209125602-c332b6f63c06/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.3/go.mod h1:/TN21ttK/J9q6uSwhBd54HahCDft0ttaMvbicHlPoso=
@@ -942,6 +943,7 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/syndtr/gocapability v0.0.0-20170704070218-db04d3cc01c8/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=


### PR DESCRIPTION
This PR will add ca-certificates to debian-slim base container. I've also upgraded the go version in this MR